### PR TITLE
Update eligible.gemspec to relax rest_client and multi_json version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Eligible
+# Eligible - Inbox Health Fork
 
 Ruby bindings for the [Eligible API](https://eligibleapi.com/rest-api-v1)
 

--- a/eligible.gemspec
+++ b/eligible.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('test-unit')
   gem.add_development_dependency('rake')
 
-  gem.add_dependency('rest-client', '~> 1.6.7')
-  gem.add_dependency('multi_json', '~> 1.7.9')
+  gem.add_dependency('rest-client', '>= 1.6.7')
+  gem.add_dependency('multi_json', '>= 1.7.9')
 end

--- a/lib/eligible.rb
+++ b/lib/eligible.rb
@@ -31,8 +31,8 @@ require 'eligible/errors/invalid_request_error'
 module Eligible
   @@api_key = nil
   @@test = false
-  @@api_base = 'https://gds.eligibleapi.com/v1.1'
-  @@api_version = 1.1
+  @@api_base = 'https://gds.eligibleapi.com/v1.3'
+  @@api_version = 1.3
 
   def self.api_url(url='')
     @@api_base + url.to_s


### PR DESCRIPTION
The eligible-ruby gem works fine with the newer minor versions of these gems.